### PR TITLE
Strip EXIF data and remove originals.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,14 +42,20 @@ image_processing:
     source: photos/original
     destination: photos/large
     resize_to_limit: [2048, 2048]
+    saver:
+      strip: true
   thumbnail:
     source: photos/original
     destination: photos/thumbnail
     resize_to_limit: [640, 640]
+    saver:
+      strip: true
   tint:
     source: photos/original
     destination: photos/tint
     resize_to_fill: [1,1]
+    saver:
+      strip: true
 
 # exiftag:
 #  sources:

--- a/_plugins/destory_originals.rb
+++ b/_plugins/destory_originals.rb
@@ -1,0 +1,31 @@
+module Jekyll
+  module DestroyOriginals
+    def self.init(site)
+      @JEKYLL_CONFIG = site.config
+    end
+
+    def self.jekyll_config
+      @JEKYLL_CONFIG || Jekyll.configuration({})
+    end
+
+    def self.destroy
+      directories = jekyll_config["image_processing"].each_with_object([]) do |(size, size_options), array|
+        directory = File.join(jekyll_config["destination"], size_options["source"])
+        if directory != jekyll_config["destination"]
+          array.push(directory)
+        end
+      end
+      directories.each do |directory|
+        FileUtils.rm_f(Dir.glob("#{directory}/*.jp*g"))
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register :site, :after_reset do |jekyll|
+  Jekyll::DestroyOriginals.init(jekyll)
+end
+
+Jekyll::Hooks.register :site, :post_write do |page|
+  Jekyll::DestroyOriginals.destroy
+end


### PR DESCRIPTION
This will help remove identifying information that could accidentally leak.

- Strips EXIF data from all processed images. This will not conflict with `jekyll-exif-data`, it will still be able to pull out anything during processing.
- Removes the unused source photo directories from the built `_site`.