### PR TITLE
Render photo pages with JS to improve build-time.

### DIFF
--- a/_includes/photos.html
+++ b/_includes/photos.html
@@ -1,0 +1,3 @@
+{% for image in images %}
+	{% include photo.html %}
+{% endfor %}

--- a/_plugins/photo_pages.rb
+++ b/_plugins/photo_pages.rb
@@ -26,7 +26,7 @@ module Jekyll
       self.read_yaml(File.join(base), "index.html")
 
       self.data["title"] = name
-      self.data["image"] = basename
+      self.data["images"] = [file]
       self.data["image_slug"] = slug
     end
   end

--- a/index.html
+++ b/index.html
@@ -4,12 +4,11 @@
 <!doctype html>
 <html>
 {% include head.html %}
-	<body>
-		<ul class="grid">
-			{% assign images = site.static_files | photo_filter %}
-			{% for image in images %}
-				{% include photo.html %}
-			{% endfor %}
+<body>
+	{% assign target = "target" %}
+	<ul class="grid" id="{{ target }}">
+		{% assign images = page.images | default: site.static_files | photo_filter %}
+		{% include photos.html %}
 		</ul>
 		<ul class="links">
 			<!-- You can add links (to your social media profiles for example) below -->	
@@ -19,5 +18,8 @@
 			<!-- <li><a rel="me" href="https://instagram.com/{{ site.instagram_username }}" title="@{{ site.instagram_username }} on Instagram">Instagram</a></li> -->
 		</ul>
 		{% include javascript.html %}
-	</body>
+		{% if page.image_slug %}
+			<script src="{{ '/js/photos.js' | relative_url }}" data-photo-id="{{ page.image_slug }}" data-target-id="{{ target }}"></script>
+		{% endif %}
+</body>
 </html>

--- a/js/photos.js
+++ b/js/photos.js
@@ -1,0 +1,11 @@
+---
+---
+{% assign images = site.static_files | photo_filter %}
+(function(html) {
+  const photo = document.currentScript.getAttribute('data-photo-id');
+  const target = document.currentScript.getAttribute('data-target-id');
+  const container = document.querySelector(`#${target}`);
+  container.innerHTML = html;
+  document.querySelector(`#${photo}`).classList.add(TARGET_CLASS);
+  lazyload();
+})(`{% include photos.html %}`);


### PR DESCRIPTION
The build-time penalty of #19 was bothering me.

Previously, every photo was rendered repeatedly on each of the individual pages. This created a slow nested loop.

This update renders just the primary photo on the individual pages and brings the rest in through a js include.

The result looks/works the same, but it makes rendering happen at about the same speed as before #19. 

Results (with cached processed images):

Before: `done in 41.46 seconds.`
After: `done in 2.533 seconds.`