### PR TITLE
Cache processed images.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/benubois/jekyll_image_processing
-  revision: 3c3dab7e979c29585361ce6b4e04ca91a404e058
+  revision: e4a262620db88b5c5672d3398b120abc5fb74a61
   specs:
     jekyll_image_processing (0.1.0)
       image_processing (>= 1.10.3)

--- a/_plugins/netlify_cache.rb
+++ b/_plugins/netlify_cache.rb
@@ -1,0 +1,54 @@
+module Jekyll
+  module NetlifyCache
+    def self.init(site)
+      @JEKYLL_CONFIG = site.config
+    end
+
+    def self.jekyll_config
+      @JEKYLL_CONFIG || Jekyll.configuration({})
+    end
+
+    def self.extract_cache
+      if cache? && File.directory?(cache_directory)
+        FileUtils.copy_entry cache_directory, build_directory
+      end
+    end
+
+    def self.cache_files
+      if cache?
+        FileUtils.rm_rf(cache_base)
+        Dir.mkdir(cache_base)
+        FileUtils.copy_entry build_directory, cache_directory
+      end
+    end
+
+    def self.cache?
+      !build_base.nil?
+    end
+
+    def self.build_directory
+      File.join(build_base, "repo", "_site")
+    end
+
+    def self.cache_directory
+      File.join(cache_base, "_site")
+    end
+
+    def self.cache_base
+      File.join(build_base, "cache", "jekyll")
+    end
+
+    def self.build_base
+      ENV["NETLIFY_BUILD_BASE"]
+    end
+  end
+end
+
+Jekyll::Hooks.register :site, :after_reset do |jekyll|
+  Jekyll::NetlifyCache.init(jekyll)
+  Jekyll::NetlifyCache.extract_cache
+end
+
+Jekyll::Hooks.register :site, :post_write do |page|
+  Jekyll::NetlifyCache.cache_files
+end

--- a/_plugins/netlify_context.rb
+++ b/_plugins/netlify_context.rb
@@ -1,5 +1,5 @@
 module Jekyll
-  class Netlify < Generator
+  class NetlifyContext < Generator
     def generate(site)
       if ENV["CONTEXT"] != "production" && ENV["DEPLOY_PRIME_URL"]
         site.config['url'] = ENV["DEPLOY_PRIME_URL"]


### PR DESCRIPTION
This caches processed images for reuse between builds. This should dramatically speed up deploys to Netlify.

Changing processing settings in `_config.yml` will automatically invalidate the cache and re-process the affected images.