### PR TITLE
Fix entry point for container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN ruby -v && gem install bundler jekyll && bundle install
 
 EXPOSE 4000
 
-ENTRYPOINT bundle exec jekyll serve
+ENTRYPOINT bundle exec jekyll serve --host 0.0.0.0


### PR DESCRIPTION
Issues have been seen with the docker entrypoint  - updating Dockerfile with the suggested fix from [!53](https://github.com/maxvoltar/photo-stream/issues/53)