### PR TITLE
Fix for opening photos with numeric IDs (fixes #67)

### DIFF
--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -14,7 +14,7 @@
   }
 
   const openPhoto = (id, href) => {
-    const photo = document.querySelector(`#${id}`);
+    const photo = document.getElementById(id);
     const title = photo.getAttribute('title');
     removeTargetClass();
     photo.classList.add(TARGET_CLASS);


### PR DESCRIPTION
`document.querySelector` will barf on IDs that start with a number, but `document.getElementById` won't.