### PR TITLE
Fix social images in image pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,15 +6,15 @@
 	<meta property="og:title" content="{{ page.title | default: site.title }}">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="{{ page.url | absolute_url }}">
-	<meta property="og:image" content="{{ site.url }}{{ page.image | uri_escape | processed_path: 'large' }}">
+	<meta property="og:image" content="{{ site.url }}{{ page.images[0].name | uri_escape | processed_path: 'large' }}">
 	<meta property="og:site_name" content="{{ site.title }}">
 	<meta property="og:description" content="{{ site.description }}">
-	<meta name="thumbnail" content="{{ site.url }}{{ page.image | uri_escape | processed_path: 'large' }}">
+	<meta name="thumbnail" content="{{ site.url }}{{ page.images[0].name | uri_escape | processed_path: 'large' }}">
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:site" content="{{ site.twitter_username }}">
 	<meta name="twitter:title" content="{{ page.title | default: site.title }}">
 	<meta name="twitter:description" content="{{ site.description }}">
-	<meta name="twitter:image:src" content="{{ site.url }}{{ page.image | uri_escape | processed_path: 'large' }}">
+	<meta name="twitter:image:src" content="{{ site.url }}{{ page.images[0].name | uri_escape | processed_path: 'large' }}">
 	<meta name="description" content="{{ site.description }}">
 	<script type="text/javascript" src="{{ '/js/lazy-loading.js' | relative_url }}"></script>
 	<link rel="stylesheet" type="text/css" media="screen" href="{{ '/css/master.css' | relative_url }}" />


### PR DESCRIPTION
This worked for me to fix #61. I'm no jekyll expert so I'm not really sure why `page.image` is set in other templates, but `_head` only has access to a `pages.images[]` array.

I confirmed by running the following `curl` command on one of my image pages:

```
> curl -s http://127.0.0.1:4000/hawes-sunset/ | grep ':image\|thumbnail"'
    <meta property="og:image" content="http://localhost:4000/photos/large/Hawes%20sunset-686656.jpeg">
    <meta name="thumbnail" content="http://localhost:4000/photos/large/Hawes%20sunset-686656.jpeg">
    <meta name="twitter:image:src" content="http://localhost:4000/photos/large/Hawes%20sunset-686656.jpeg">
```